### PR TITLE
Add Audio-to-Cartoon Video Studio (Canvas + Web Audio + WebM export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
-# Your GitHub Learning Lab Repository for Introducing GitHub
+# Audio-to-Cartoon Video Studio
 
-Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.
+This repository now hosts a browser-based website that turns uploaded audio into a cartoon-style animated video experience without using Flask.
 
-Oh! I haven't introduced myself...
+## What it does
 
-I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey to learn and master the various topics covered in this course. I will be using Issue and Pull Request comments to communicate with you. In fact, I already added an issue for you to check out.
+- Upload a primary audio track for narration, speech, rap, or singing.
+- Add optional background music with an adjustable mix level.
+- Preview a synchronized cartoon stage with animated characters, lip-sync motion, and audio-reactive effects.
+- Export the result as a downloadable WebM video using browser-native media APIs.
 
-![issue tab](https://lab.github.com/public/images/issue_tab.png)
+## Technical approach
 
-I'll meet you over there, can't wait to get started!
+The website is intentionally built with common, runtime-safe web platform features instead of a server framework:
 
-This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+- **Jekyll** for static-site delivery in this repo.
+- **Canvas 2D** for the animated cartoon stage.
+- **Web Audio API** for audio decoding, waveform energy analysis, and mixing.
+- **MediaRecorder** for client-side video export.
+
+## Run locally
+
+If your Ruby/Jekyll environment is available, use the existing project scripts:
+
+```bash
+./script/setup
+./script/server
+```
+
+Then open the local Jekyll site in your browser and upload your audio files.

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page.title | default: site.title }}</title>
+  <meta name="description" content="Create a cartoon music video from spoken audio with synchronized animation and optional background music.">
+  <link rel="stylesheet" href="{{ '/assets/css/app.css' | relative_url }}">
+</head>
+<body>
+  {{ content }}
+  <script src="{{ '/assets/js/app.js' | relative_url }}"></script>
+</body>
+</html>

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,0 +1,337 @@
+:root {
+  --bg: #07111f;
+  --card: rgba(9, 18, 34, 0.86);
+  --card-strong: rgba(14, 25, 46, 0.96);
+  --line: rgba(255, 255, 255, 0.11);
+  --text: #ecf4ff;
+  --muted: #9fb6d6;
+  --accent: #78f0d9;
+  --accent-2: #ff7dcf;
+  --accent-3: #ffd36e;
+  --shadow: 0 24px 90px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', system-ui, sans-serif;
+  background:
+    radial-gradient(circle at top, rgba(120, 240, 217, 0.22), transparent 28%),
+    radial-gradient(circle at right, rgba(255, 125, 207, 0.14), transparent 24%),
+    linear-gradient(180deg, #091524 0%, #040814 100%);
+  color: var(--text);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.page-shell {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 56px;
+}
+
+.hero-card,
+.control-card,
+.preview-card,
+.feature-grid article {
+  background: var(--card);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.hero-card {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(260px, 0.9fr);
+  gap: 24px;
+  padding: 30px;
+  border-radius: 28px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  margin: 0 0 14px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(120, 240, 217, 0.12);
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.hero-copy h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 3.8vw, 4.4rem);
+  line-height: 1.02;
+}
+
+.hero-text,
+.preview-header p,
+.feature-grid p,
+.field small,
+.status-panel p,
+.hero-stats span,
+.legend span {
+  color: var(--muted);
+}
+
+.hero-text {
+  max-width: 65ch;
+  font-size: 1.02rem;
+  line-height: 1.65;
+}
+
+.hero-pills,
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.hero-pills span,
+.legend span {
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.9rem;
+}
+
+.hero-stats {
+  display: grid;
+  gap: 14px;
+}
+
+.hero-stats div {
+  padding: 18px;
+  border-radius: 22px;
+  background: var(--card-strong);
+  border: 1px solid var(--line);
+}
+
+.hero-stats strong {
+  display: block;
+  font-size: 2rem;
+  margin-bottom: 6px;
+}
+
+.studio-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.control-card,
+.preview-card {
+  border-radius: 28px;
+  padding: 24px;
+}
+
+.control-card h2,
+.preview-card h2,
+.feature-grid h3 {
+  margin-top: 0;
+}
+
+.control-form {
+  display: grid;
+  gap: 16px;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field > span,
+.field-row {
+  font-weight: 600;
+}
+
+.field-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+input[type='file'],
+select,
+input[type='range'] {
+  width: 100%;
+}
+
+input[type='file'],
+select {
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+}
+
+input[type='file']::file-selector-button {
+  margin-right: 12px;
+  border: 0;
+  border-radius: 999px;
+  padding: 9px 14px;
+  font-weight: 700;
+  color: #031217;
+  background: linear-gradient(135deg, var(--accent), #a3ffef);
+}
+
+input[type='range'] {
+  accent-color: var(--accent);
+}
+
+.button-row,
+.transport {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+button {
+  cursor: pointer;
+  border: 0;
+  border-radius: 16px;
+  padding: 14px 18px;
+  font-weight: 700;
+  transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.primary-btn {
+  color: #031217;
+  background: linear-gradient(135deg, var(--accent), #bbfff4);
+  box-shadow: 0 12px 30px rgba(120, 240, 217, 0.25);
+}
+
+.secondary-btn,
+#stop-btn {
+  color: var(--text);
+  background: linear-gradient(135deg, rgba(255, 125, 207, 0.22), rgba(255, 211, 110, 0.2));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.status-panel {
+  margin-top: 18px;
+  padding: 16px;
+  border-radius: 20px;
+  background: var(--card-strong);
+  border: 1px solid var(--line);
+}
+
+.progress-track {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+#progress-bar {
+  display: block;
+  width: 0%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2), var(--accent-3));
+  transition: width 180ms linear;
+}
+
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
+  margin-bottom: 18px;
+}
+
+#scene-canvas {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  display: block;
+  border-radius: 24px;
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, #101f39 0%, #09111f 100%);
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  display: inline-block;
+  border-radius: 50%;
+  margin-right: 8px;
+}
+
+.dot.voice { background: var(--accent); }
+.dot.music { background: var(--accent-2); }
+.dot.export { background: var(--accent-3); }
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  margin-top: 24px;
+}
+
+.feature-grid article {
+  padding: 22px;
+  border-radius: 24px;
+}
+
+@media (max-width: 980px) {
+  .hero-card,
+  .studio-grid,
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-header {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-shell {
+    width: min(100% - 20px, 1200px);
+    padding-top: 18px;
+  }
+
+  .hero-card,
+  .control-card,
+  .preview-card,
+  .feature-grid article {
+    border-radius: 22px;
+  }
+
+  .hero-card,
+  .control-card,
+  .preview-card {
+    padding: 18px;
+  }
+
+  .button-row button,
+  .transport button {
+    width: 100%;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,738 @@
+const dom = {
+  voiceFile: document.querySelector('#voice-file'),
+  musicFile: document.querySelector('#music-file'),
+  moodSelect: document.querySelector('#mood-select'),
+  characterStyle: document.querySelector('#character-style'),
+  musicVolume: document.querySelector('#music-volume'),
+  musicVolumeOutput: document.querySelector('#music-volume-output'),
+  fxIntensity: document.querySelector('#fx-intensity'),
+  fxOutput: document.querySelector('#fx-output'),
+  previewBtn: document.querySelector('#preview-btn'),
+  exportBtn: document.querySelector('#export-btn'),
+  stopBtn: document.querySelector('#stop-btn'),
+  statusText: document.querySelector('#status-text'),
+  progressBar: document.querySelector('#progress-bar'),
+  timeLabel: document.querySelector('#time-label'),
+  canvas: document.querySelector('#scene-canvas'),
+};
+
+const ctx = dom.canvas.getContext('2d');
+const offscreenCanvas = document.createElement('canvas');
+offscreenCanvas.width = dom.canvas.width;
+offscreenCanvas.height = dom.canvas.height;
+const exportCtx = offscreenCanvas.getContext('2d');
+
+const moodThemes = {
+  sunset: {
+    skyTop: '#31255e',
+    skyBottom: '#ff9c73',
+    stage: '#5d2d4d',
+    sparkle: '#ffe599',
+    accent: '#78f0d9',
+  },
+  neon: {
+    skyTop: '#090d22',
+    skyBottom: '#24246d',
+    stage: '#1f143c',
+    sparkle: '#ff7dcf',
+    accent: '#68f2ff',
+  },
+  forest: {
+    skyTop: '#12362d',
+    skyBottom: '#3f8f6a',
+    stage: '#3f2e22',
+    sparkle: '#ffd36e',
+    accent: '#8af79a',
+  },
+  space: {
+    skyTop: '#020611',
+    skyBottom: '#182f61',
+    stage: '#17172f',
+    sparkle: '#d5ccff',
+    accent: '#7ad7ff',
+  },
+};
+
+const state = {
+  audioContext: null,
+  voiceBuffer: null,
+  musicBuffer: null,
+  voiceUrl: null,
+  musicUrl: null,
+  voiceEnergy: [0],
+  musicEnergy: [0],
+  duration: 0,
+  playing: false,
+  exporting: false,
+  animationFrame: 0,
+  startTime: 0,
+  previewSources: [],
+  previewNodes: [],
+  mediaRecorder: null,
+  exportChunks: [],
+  exportAudioContext: null,
+  lastFrameTime: 0,
+  progressTimer: null,
+  currentTime: 0,
+};
+
+function setStatus(message) {
+  dom.statusText.textContent = message;
+}
+
+function formatTime(seconds) {
+  if (!Number.isFinite(seconds)) return '00:00';
+  const mins = Math.floor(seconds / 60).toString().padStart(2, '0');
+  const secs = Math.floor(seconds % 60).toString().padStart(2, '0');
+  return `${mins}:${secs}`;
+}
+
+function updateRangeLabels() {
+  dom.musicVolumeOutput.textContent = `${dom.musicVolume.value}%`;
+  dom.fxOutput.textContent = `${dom.fxIntensity.value}%`;
+}
+
+async function getAudioContext() {
+  if (!state.audioContext) {
+    state.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+  }
+  if (state.audioContext.state === 'suspended') {
+    await state.audioContext.resume();
+  }
+  return state.audioContext;
+}
+
+async function loadAudioFile(file, key) {
+  if (!file) {
+    state[`${key}Buffer`] = null;
+    state[`${key}Energy`] = [0];
+    state[`${key}Url`] = null;
+    return;
+  }
+
+  const audioContext = await getAudioContext();
+  const arrayBuffer = await file.arrayBuffer();
+  const audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
+  state[`${key}Buffer`] = audioBuffer;
+  state[`${key}Energy`] = analyzeEnergy(audioBuffer);
+  state[`${key}Url`] = URL.createObjectURL(file);
+  syncDuration();
+}
+
+function analyzeEnergy(audioBuffer, bucketCount = 720) {
+  const channelData = audioBuffer.getChannelData(0);
+  const sampleSize = Math.max(256, Math.floor(channelData.length / bucketCount));
+  const values = [];
+
+  for (let offset = 0; offset < channelData.length; offset += sampleSize) {
+    let total = 0;
+    const end = Math.min(offset + sampleSize, channelData.length);
+    for (let i = offset; i < end; i += 1) {
+      total += Math.abs(channelData[i]);
+    }
+    values.push(total / (end - offset || 1));
+  }
+
+  const peak = Math.max(...values, 0.001);
+  return values.map((value) => Math.min(1, value / peak));
+}
+
+function syncDuration() {
+  state.duration = Math.max(state.voiceBuffer?.duration || 0, state.musicBuffer?.duration || 0);
+  dom.timeLabel.textContent = `${formatTime(state.currentTime)} / ${formatTime(state.duration)}`;
+}
+
+function energyAt(values, time) {
+  if (!values.length || !state.duration) return 0;
+  const progress = Math.min(0.999, Math.max(0, time / state.duration));
+  const index = Math.floor(progress * values.length);
+  return values[index] || 0;
+}
+
+function getSceneSnapshot(time) {
+  const voice = energyAt(state.voiceEnergy, time);
+  const music = energyAt(state.musicEnergy, time);
+  const combined = Math.min(1, voice * 0.78 + music * 0.44);
+  const fxScale = Number(dom.fxIntensity.value) / 100;
+  return {
+    time,
+    voice,
+    music,
+    combined,
+    fxScale,
+    theme: moodThemes[dom.moodSelect.value],
+    characterStyle: dom.characterStyle.value,
+  };
+}
+
+function drawFrame(targetCtx, snapshot) {
+  const { width, height } = targetCtx.canvas;
+  const { theme, time, voice, music, combined, fxScale, characterStyle } = snapshot;
+  const pulse = 0.5 + Math.sin(time * 2.8) * 0.5;
+
+  const gradient = targetCtx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, theme.skyTop);
+  gradient.addColorStop(1, theme.skyBottom);
+  targetCtx.fillStyle = gradient;
+  targetCtx.fillRect(0, 0, width, height);
+
+  drawGlow(targetCtx, width * 0.5, height * 0.18, 180 + combined * 90, `rgba(255,255,255,${0.08 + combined * 0.08})`);
+  drawGlow(targetCtx, width * 0.18, height * 0.22, 110 + music * 70, `${hexToRgba(theme.accent, 0.2)}`);
+  drawGlow(targetCtx, width * 0.82, height * 0.18, 130 + voice * 90, `${hexToRgba(theme.sparkle, 0.18)}`);
+
+  drawStage(targetCtx, snapshot);
+  drawSpectrum(targetCtx, snapshot);
+  drawSparkles(targetCtx, snapshot, pulse);
+  drawCharacters(targetCtx, snapshot, characterStyle);
+  drawSpeechBubble(targetCtx, snapshot);
+  drawOverlay(targetCtx, snapshot);
+}
+
+function drawGlow(targetCtx, x, y, radius, color) {
+  const gradient = targetCtx.createRadialGradient(x, y, 0, x, y, radius);
+  gradient.addColorStop(0, color);
+  gradient.addColorStop(1, 'rgba(255,255,255,0)');
+  targetCtx.fillStyle = gradient;
+  targetCtx.beginPath();
+  targetCtx.arc(x, y, radius, 0, Math.PI * 2);
+  targetCtx.fill();
+}
+
+function drawStage(targetCtx, snapshot) {
+  const { width, height } = targetCtx.canvas;
+  targetCtx.fillStyle = hexToRgba(snapshot.theme.stage, 0.96);
+  targetCtx.beginPath();
+  targetCtx.moveTo(0, height * 0.74);
+  targetCtx.quadraticCurveTo(width * 0.5, height * 0.62, width, height * 0.74);
+  targetCtx.lineTo(width, height);
+  targetCtx.lineTo(0, height);
+  targetCtx.closePath();
+  targetCtx.fill();
+
+  targetCtx.fillStyle = 'rgba(255,255,255,0.05)';
+  for (let i = 0; i < 8; i += 1) {
+    const stripeHeight = 16 + Math.sin(snapshot.time * 3 + i) * 5;
+    targetCtx.fillRect(0, height * 0.78 + i * 18, width, stripeHeight);
+  }
+}
+
+function drawSpectrum(targetCtx, snapshot) {
+  const { width, height } = targetCtx.canvas;
+  const barCount = 28;
+  const baseY = height * 0.72;
+
+  for (let i = 0; i < barCount; i += 1) {
+    const ratio = i / (barCount - 1);
+    const wobble = Math.sin(snapshot.time * 5 + i * 0.8) * 0.5 + 0.5;
+    const heightFactor = 26 + snapshot.combined * 120 * wobble + snapshot.music * 55;
+    const barWidth = width / barCount - 8;
+    const x = 18 + i * (width / barCount);
+    const barHeight = heightFactor * (0.55 + ratio * 0.45);
+
+    targetCtx.fillStyle = i % 2 === 0 ? hexToRgba(snapshot.theme.accent, 0.7) : hexToRgba(snapshot.theme.sparkle, 0.64);
+    roundRect(targetCtx, x, baseY - barHeight, barWidth, barHeight, 14, true, false);
+  }
+}
+
+function drawSparkles(targetCtx, snapshot, pulse) {
+  const { width, height } = targetCtx.canvas;
+  const count = 12 + Math.round(snapshot.fxScale * 18);
+  for (let i = 0; i < count; i += 1) {
+    const seed = i + 1;
+    const x = ((seed * 97 + snapshot.time * 90 * (0.4 + snapshot.music)) % (width + 100)) - 50;
+    const y = 80 + ((seed * 57 + snapshot.time * 55 * (0.25 + snapshot.voice)) % (height * 0.5));
+    const radius = 3 + ((seed % 5) * 1.6 + pulse * 3 + snapshot.combined * 7);
+    targetCtx.fillStyle = i % 3 === 0 ? snapshot.theme.sparkle : snapshot.theme.accent;
+    star(targetCtx, x, y, radius, radius * 1.8, 5, 0.4 + pulse * 0.8);
+    targetCtx.fill();
+  }
+}
+
+function drawCharacters(targetCtx, snapshot, style) {
+  const { width, height } = targetCtx.canvas;
+  const configs = {
+    solo: [{ x: 0.5, scale: 1.18, color: '#ffd36e', accent: '#ff7dcf' }],
+    duo: [
+      { x: 0.36, scale: 1.04, color: '#78f0d9', accent: '#ffd36e' },
+      { x: 0.64, scale: 0.98, color: '#ff9ad9', accent: '#9affaf' },
+    ],
+    band: [
+      { x: 0.25, scale: 0.9, color: '#78f0d9', accent: '#ffd36e' },
+      { x: 0.5, scale: 1.08, color: '#ff9ad9', accent: '#68f2ff' },
+      { x: 0.75, scale: 0.94, color: '#ffd36e', accent: '#b995ff' },
+    ],
+  };
+
+  const characters = configs[style];
+  characters.forEach((character, index) => {
+    const bounce = Math.sin(snapshot.time * 6 + index) * (12 + snapshot.combined * 26 * snapshot.fxScale);
+    const sway = Math.sin(snapshot.time * 2.5 + index * 1.8) * (10 + snapshot.music * 24);
+    const mouth = 8 + snapshot.voice * 22 + (index % 2) * 4;
+    const x = width * character.x + sway;
+    const y = height * 0.66 - bounce;
+    drawCartoonCharacter(targetCtx, {
+      x,
+      y,
+      scale: character.scale,
+      bodyColor: character.color,
+      accentColor: character.accent,
+      mouthOpen: mouth,
+      armSwing: snapshot.combined,
+      blink: Math.sin(snapshot.time * 1.4 + index * 2.2) > 0.96,
+      spotlight: index === 1 || characters.length === 1,
+    });
+  });
+}
+
+function drawCartoonCharacter(targetCtx, options) {
+  const {
+    x,
+    y,
+    scale,
+    bodyColor,
+    accentColor,
+    mouthOpen,
+    armSwing,
+    blink,
+    spotlight,
+  } = options;
+
+  targetCtx.save();
+  targetCtx.translate(x, y);
+  targetCtx.scale(scale, scale);
+
+  if (spotlight) {
+    targetCtx.fillStyle = 'rgba(255,255,255,0.08)';
+    targetCtx.beginPath();
+    targetCtx.moveTo(-80, -230);
+    targetCtx.lineTo(80, -230);
+    targetCtx.lineTo(160, 130);
+    targetCtx.lineTo(-160, 130);
+    targetCtx.closePath();
+    targetCtx.fill();
+  }
+
+  targetCtx.strokeStyle = 'rgba(0,0,0,0.35)';
+  targetCtx.lineWidth = 6;
+  targetCtx.lineCap = 'round';
+
+  targetCtx.fillStyle = bodyColor;
+  roundRect(targetCtx, -64, -60, 128, 152, 40, true, true);
+
+  targetCtx.fillStyle = '#ffe5c7';
+  targetCtx.beginPath();
+  targetCtx.arc(0, -120, 64, 0, Math.PI * 2);
+  targetCtx.fill();
+  targetCtx.stroke();
+
+  targetCtx.fillStyle = accentColor;
+  targetCtx.beginPath();
+  targetCtx.arc(-36, -172, 16, 0, Math.PI * 2);
+  targetCtx.arc(36, -172, 16, 0, Math.PI * 2);
+  targetCtx.fill();
+
+  targetCtx.strokeStyle = '#18212f';
+  targetCtx.lineWidth = 5;
+  const eyeY = -132;
+  targetCtx.beginPath();
+  if (blink) {
+    targetCtx.moveTo(-25, eyeY);
+    targetCtx.lineTo(-5, eyeY + 1);
+    targetCtx.moveTo(5, eyeY + 1);
+    targetCtx.lineTo(25, eyeY);
+  } else {
+    targetCtx.arc(-15, eyeY, 8, 0, Math.PI * 2);
+    targetCtx.arc(15, eyeY, 8, 0, Math.PI * 2);
+  }
+  targetCtx.stroke();
+
+  targetCtx.fillStyle = '#ff6f7f';
+  targetCtx.beginPath();
+  targetCtx.ellipse(0, -95, 18, mouthOpen, 0, 0, Math.PI * 2);
+  targetCtx.fill();
+
+  targetCtx.strokeStyle = '#18212f';
+  targetCtx.lineWidth = 8;
+  const armOffset = 18 + armSwing * 30;
+  targetCtx.beginPath();
+  targetCtx.moveTo(-48, -20);
+  targetCtx.lineTo(-92, 8 - armOffset);
+  targetCtx.moveTo(48, -20);
+  targetCtx.lineTo(92, 8 + armOffset);
+  targetCtx.moveTo(-20, 88);
+  targetCtx.lineTo(-30, 150);
+  targetCtx.moveTo(20, 88);
+  targetCtx.lineTo(30, 150);
+  targetCtx.stroke();
+
+  targetCtx.fillStyle = accentColor;
+  roundRect(targetCtx, -34, 4, 68, 26, 12, true, false);
+
+  targetCtx.restore();
+}
+
+function drawSpeechBubble(targetCtx, snapshot) {
+  const { width } = targetCtx.canvas;
+  const bubbleWidth = 310;
+  const bubbleHeight = 94;
+  const x = width - bubbleWidth - 42;
+  const y = 38;
+  const energyWord = snapshot.voice > 0.7 ? 'BIG CHORUS!' : snapshot.voice > 0.35 ? 'IN SYNC!' : 'READY TO GROOVE';
+
+  targetCtx.fillStyle = 'rgba(255,255,255,0.92)';
+  roundRect(targetCtx, x, y, bubbleWidth, bubbleHeight, 24, true, false);
+  targetCtx.beginPath();
+  targetCtx.moveTo(x + 55, y + bubbleHeight - 6);
+  targetCtx.lineTo(x + 80, y + bubbleHeight + 22);
+  targetCtx.lineTo(x + 100, y + bubbleHeight - 6);
+  targetCtx.closePath();
+  targetCtx.fill();
+
+  targetCtx.fillStyle = '#142034';
+  targetCtx.font = '700 18px Inter, sans-serif';
+  targetCtx.fillText('Cartoon stage AI mix', x + 24, y + 34);
+  targetCtx.font = '800 30px Inter, sans-serif';
+  targetCtx.fillText(energyWord, x + 24, y + 70);
+}
+
+function drawOverlay(targetCtx, snapshot) {
+  const { width, height } = targetCtx.canvas;
+  targetCtx.fillStyle = 'rgba(8, 13, 24, 0.35)';
+  roundRect(targetCtx, 24, 24, 240, 102, 22, true, false);
+
+  targetCtx.fillStyle = '#f4fbff';
+  targetCtx.font = '700 18px Inter, sans-serif';
+  targetCtx.fillText('Voice energy', 44, 58);
+  targetCtx.fillText('Music energy', 44, 96);
+
+  drawMeter(targetCtx, 150, 42, 90, 18, snapshot.voice, '#78f0d9');
+  drawMeter(targetCtx, 150, 80, 90, 18, snapshot.music, '#ff7dcf');
+
+  targetCtx.fillStyle = 'rgba(255,255,255,0.65)';
+  targetCtx.font = '600 16px Inter, sans-serif';
+  targetCtx.fillText(`${dom.moodSelect.options[dom.moodSelect.selectedIndex].text} • ${dom.characterStyle.options[dom.characterStyle.selectedIndex].text}`, 24, height - 26);
+}
+
+function drawMeter(targetCtx, x, y, width, height, value, color) {
+  targetCtx.fillStyle = 'rgba(255,255,255,0.12)';
+  roundRect(targetCtx, x, y, width, height, 999, true, false);
+  targetCtx.fillStyle = color;
+  roundRect(targetCtx, x, y, width * Math.max(0.08, value), height, 999, true, false);
+}
+
+function hexToRgba(hex, alpha) {
+  const sanitized = hex.replace('#', '');
+  const bigint = parseInt(sanitized, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function roundRect(targetCtx, x, y, width, height, radius, fill, stroke) {
+  const r = Math.min(radius, width / 2, height / 2);
+  targetCtx.beginPath();
+  targetCtx.moveTo(x + r, y);
+  targetCtx.arcTo(x + width, y, x + width, y + height, r);
+  targetCtx.arcTo(x + width, y + height, x, y + height, r);
+  targetCtx.arcTo(x, y + height, x, y, r);
+  targetCtx.arcTo(x, y, x + width, y, r);
+  targetCtx.closePath();
+  if (fill) targetCtx.fill();
+  if (stroke) targetCtx.stroke();
+}
+
+function star(targetCtx, x, y, innerRadius, outerRadius, points, rotation) {
+  targetCtx.beginPath();
+  for (let i = 0; i < points * 2; i += 1) {
+    const radius = i % 2 === 0 ? outerRadius : innerRadius;
+    const angle = rotation + (Math.PI * i) / points;
+    const px = x + Math.cos(angle) * radius;
+    const py = y + Math.sin(angle) * radius;
+    if (i === 0) targetCtx.moveTo(px, py);
+    else targetCtx.lineTo(px, py);
+  }
+  targetCtx.closePath();
+}
+
+function renderPreviewFrame() {
+  if (!state.playing) return;
+  const audioContext = state.audioContext;
+  const currentTime = Math.max(0, audioContext.currentTime - state.startTime);
+  state.currentTime = currentTime;
+  dom.timeLabel.textContent = `${formatTime(currentTime)} / ${formatTime(state.duration)}`;
+  dom.progressBar.style.width = `${Math.min(100, (currentTime / state.duration) * 100)}%`;
+
+  const snapshot = getSceneSnapshot(currentTime);
+  drawFrame(ctx, snapshot);
+
+  if (currentTime >= state.duration) {
+    stopPlayback();
+    setStatus('Preview finished. You can adjust settings and export a video when ready.');
+    return;
+  }
+
+  state.animationFrame = window.requestAnimationFrame(renderPreviewFrame);
+}
+
+function clearPreview() {
+  drawFrame(ctx, getSceneSnapshot(0));
+  state.currentTime = 0;
+  dom.progressBar.style.width = '0%';
+  dom.timeLabel.textContent = `${formatTime(0)} / ${formatTime(state.duration)}`;
+}
+
+function stopPlayback() {
+  state.playing = false;
+  window.cancelAnimationFrame(state.animationFrame);
+  state.previewSources.forEach((source) => {
+    try {
+      source.stop();
+    } catch (error) {
+      // Source may already be stopped.
+    }
+  });
+  state.previewSources = [];
+  state.previewNodes.forEach((node) => node.disconnect());
+  state.previewNodes = [];
+}
+
+function stopEverything() {
+  stopPlayback();
+  if (state.mediaRecorder && state.mediaRecorder.state !== 'inactive') {
+    state.mediaRecorder.stop();
+  }
+  if (state.exportAudioContext && state.exportAudioContext.state !== 'closed') {
+    state.exportAudioContext.close();
+  }
+  state.exportAudioContext = null;
+  state.exporting = false;
+  clearPreview();
+  setStatus('Playback stopped.');
+}
+
+function createBufferSource(audioContext, audioBuffer, gainValue, destination) {
+  const source = audioContext.createBufferSource();
+  source.buffer = audioBuffer;
+  const gainNode = audioContext.createGain();
+  gainNode.gain.value = gainValue;
+  source.connect(gainNode);
+  gainNode.connect(destination);
+  return { source, gainNode };
+}
+
+async function startPreview() {
+  if (!state.voiceBuffer) {
+    setStatus('Please upload a main audio track before previewing.');
+    return;
+  }
+
+  stopPlayback();
+  await getAudioContext();
+
+  const destination = state.audioContext.destination;
+  const voiceTrack = createBufferSource(state.audioContext, state.voiceBuffer, 1, destination);
+  state.previewSources.push(voiceTrack.source);
+  state.previewNodes.push(voiceTrack.gainNode);
+
+  if (state.musicBuffer) {
+    const musicTrack = createBufferSource(
+      state.audioContext,
+      state.musicBuffer,
+      Number(dom.musicVolume.value) / 100,
+      destination,
+    );
+    state.previewSources.push(musicTrack.source);
+    state.previewNodes.push(musicTrack.gainNode);
+    musicTrack.source.start();
+  }
+
+  voiceTrack.source.start();
+  state.startTime = state.audioContext.currentTime;
+  state.playing = true;
+  setStatus('Previewing your synchronized cartoon scene...');
+  renderPreviewFrame();
+}
+
+async function exportVideo() {
+  if (!state.voiceBuffer) {
+    setStatus('Upload a main audio track before exporting a video.');
+    return;
+  }
+
+  if (state.exporting) {
+    return;
+  }
+
+  stopPlayback();
+  state.exporting = true;
+  dom.exportBtn.disabled = true;
+  dom.previewBtn.disabled = true;
+  setStatus('Exporting WebM video. Keep this tab open until the download starts...');
+
+  const exportAudioContext = new (window.AudioContext || window.webkitAudioContext)();
+  state.exportAudioContext = exportAudioContext;
+  const mediaDestination = exportAudioContext.createMediaStreamDestination();
+
+  const voiceTrack = createBufferSource(exportAudioContext, state.voiceBuffer, 1, mediaDestination);
+  const exportNodes = [voiceTrack.gainNode];
+  voiceTrack.source.start();
+
+  if (state.musicBuffer) {
+    const musicTrack = createBufferSource(
+      exportAudioContext,
+      state.musicBuffer,
+      Number(dom.musicVolume.value) / 100,
+      mediaDestination,
+    );
+    exportNodes.push(musicTrack.gainNode);
+    musicTrack.source.start();
+  }
+
+  const canvasStream = offscreenCanvas.captureStream(30);
+  const combinedStream = new MediaStream([
+    ...canvasStream.getVideoTracks(),
+    ...mediaDestination.stream.getAudioTracks(),
+  ]);
+
+  const recorder = new MediaRecorder(combinedStream, {
+    mimeType: MediaRecorder.isTypeSupported('video/webm;codecs=vp9,opus')
+      ? 'video/webm;codecs=vp9,opus'
+      : 'video/webm;codecs=vp8,opus',
+  });
+
+  state.exportChunks = [];
+  state.mediaRecorder = recorder;
+
+  recorder.ondataavailable = (event) => {
+    if (event.data.size > 0) {
+      state.exportChunks.push(event.data);
+    }
+  };
+
+  recorder.onstop = async () => {
+    exportNodes.forEach((node) => node.disconnect());
+    if (state.exportAudioContext && state.exportAudioContext.state !== 'closed') {
+      await state.exportAudioContext.close();
+    }
+    state.exportAudioContext = null;
+
+    const blob = new Blob(state.exportChunks, { type: 'video/webm' });
+    const downloadUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = downloadUrl;
+    anchor.download = `cartoon-audio-video-${Date.now()}.webm`;
+    anchor.click();
+    URL.revokeObjectURL(downloadUrl);
+
+    dom.exportBtn.disabled = false;
+    dom.previewBtn.disabled = false;
+    state.exporting = false;
+    dom.progressBar.style.width = '100%';
+    setStatus('Video exported successfully. Your browser should download the WebM file now.');
+  };
+
+  recorder.start(250);
+
+  const startedAt = performance.now();
+  const renderExportLoop = () => {
+    const elapsed = (performance.now() - startedAt) / 1000;
+    const clamped = Math.min(state.duration, elapsed);
+    state.currentTime = clamped;
+    dom.timeLabel.textContent = `${formatTime(clamped)} / ${formatTime(state.duration)}`;
+    dom.progressBar.style.width = `${Math.min(100, (clamped / state.duration) * 100)}%`;
+
+    const snapshot = getSceneSnapshot(clamped);
+    drawFrame(exportCtx, snapshot);
+    ctx.drawImage(offscreenCanvas, 0, 0, dom.canvas.width, dom.canvas.height);
+
+    if (clamped >= state.duration) {
+      recorder.stop();
+      return;
+    }
+
+    window.requestAnimationFrame(renderExportLoop);
+  };
+
+  renderExportLoop();
+}
+
+async function handleVoiceChange(event) {
+  const [file] = event.target.files;
+  if (!file) {
+    state.voiceBuffer = null;
+    state.voiceEnergy = [0];
+    syncDuration();
+    clearPreview();
+    setStatus('Main audio removed. Upload a file to continue.');
+    return;
+  }
+
+  setStatus(`Loading “${file.name}” and analyzing its waveform...`);
+  await loadAudioFile(file, 'voice');
+  clearPreview();
+  setStatus('Main audio loaded. Add optional background music or start previewing.');
+}
+
+async function handleMusicChange(event) {
+  const [file] = event.target.files;
+  if (!file) {
+    state.musicBuffer = null;
+    state.musicEnergy = [0];
+    syncDuration();
+    clearPreview();
+    setStatus('Background music removed. Preview will use voice audio only.');
+    return;
+  }
+
+  setStatus(`Loading background music “${file.name}”...`);
+  await loadAudioFile(file, 'music');
+  clearPreview();
+  setStatus('Background music loaded. Preview the mix or export a video.');
+}
+
+function bindEvents() {
+  dom.voiceFile.addEventListener('change', (event) => {
+    handleVoiceChange(event).catch((error) => {
+      console.error(error);
+      setStatus('Could not read the main audio file. Please try another file.');
+    });
+  });
+
+  dom.musicFile.addEventListener('change', (event) => {
+    handleMusicChange(event).catch((error) => {
+      console.error(error);
+      setStatus('Could not read the background music file. Please try another file.');
+    });
+  });
+
+  dom.musicVolume.addEventListener('input', updateRangeLabels);
+  dom.fxIntensity.addEventListener('input', updateRangeLabels);
+  dom.moodSelect.addEventListener('change', clearPreview);
+  dom.characterStyle.addEventListener('change', clearPreview);
+  dom.previewBtn.addEventListener('click', () => {
+    startPreview().catch((error) => {
+      console.error(error);
+      setStatus('Preview failed. Check whether your browser supports Web Audio playback.');
+    });
+  });
+  dom.exportBtn.addEventListener('click', () => {
+    exportVideo().catch((error) => {
+      console.error(error);
+      state.exporting = false;
+      dom.exportBtn.disabled = false;
+      dom.previewBtn.disabled = false;
+      setStatus('Export failed. Try a shorter file or a Chromium-based browser.');
+    });
+  });
+  dom.stopBtn.addEventListener('click', stopEverything);
+}
+
+function initialize() {
+  updateRangeLabels();
+  bindEvents();
+  clearPreview();
+  setStatus('Upload your voice audio to generate a cartoon animation and downloadable video.');
+}
+
+initialize();

--- a/index.html
+++ b/index.html
@@ -1,13 +1,136 @@
 ---
-layout: presentation
+layout: app
+title: Audio-to-Cartoon Video Studio
 ---
 
-{% for post in site.posts reversed %}
-	{% include slide.html %}
-	<div class="page-break"></div>
-{% endfor %}
-{% unless site.simple-slideshow %}
-{% if site.overview %}
-<section id="overview" class="step" {% for attr in site.overview-data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}></section>
-{% endif %}
-{% endunless %}
+<main class="page-shell">
+  <section class="hero-card">
+    <div class="hero-copy">
+      <p class="eyebrow">Audio to video generator</p>
+      <h1>Turn voice audio into a cartoon music video that moves in sync.</h1>
+      <p class="hero-text">
+        Upload narration or singing, blend in optional background music, and export a stylized animated video.
+        The stage reacts to your audio energy so characters bounce, lip-sync, and trigger effects in rhythm.
+      </p>
+      <div class="hero-pills">
+        <span>Browser-based</span>
+        <span>No Flask</span>
+        <span>Canvas + Web Audio + MediaRecorder</span>
+      </div>
+    </div>
+    <div class="hero-stats">
+      <div>
+        <strong>1</strong>
+        <span>Main audio track</span>
+      </div>
+      <div>
+        <strong>+1</strong>
+        <span>Optional music bed</span>
+      </div>
+      <div>
+        <strong>30fps</strong>
+        <span>Animated export</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="studio-grid">
+    <aside class="control-card">
+      <h2>Studio controls</h2>
+      <form id="studio-form" class="control-form">
+        <label class="field">
+          <span>Main audio</span>
+          <input id="voice-file" type="file" accept="audio/*" required>
+          <small>Upload speech, podcast narration, rap, or singing.</small>
+        </label>
+
+        <label class="field">
+          <span>Background music</span>
+          <input id="music-file" type="file" accept="audio/*">
+          <small>Optional. Instrumentals or ambient music work best.</small>
+        </label>
+
+        <label class="field">
+          <span>Visual mood</span>
+          <select id="mood-select">
+            <option value="sunset">Sunset Pop</option>
+            <option value="neon">Neon Stage</option>
+            <option value="forest">Cartoon Forest</option>
+            <option value="space">Space Parade</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Character style</span>
+          <select id="character-style">
+            <option value="band">Band Trio</option>
+            <option value="duo">Happy Duo</option>
+            <option value="solo">Spotlight Solo</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <div class="field-row">
+            <span>Music volume</span>
+            <output id="music-volume-output">35%</output>
+          </div>
+          <input id="music-volume" type="range" min="0" max="70" value="35">
+        </label>
+
+        <label class="field">
+          <div class="field-row">
+            <span>Effect intensity</span>
+            <output id="fx-output">70%</output>
+          </div>
+          <input id="fx-intensity" type="range" min="25" max="100" value="70">
+        </label>
+
+        <div class="button-row">
+          <button type="button" id="preview-btn" class="primary-btn">Preview animation</button>
+          <button type="button" id="export-btn" class="secondary-btn">Export video</button>
+        </div>
+      </form>
+
+      <div class="status-panel">
+        <p id="status-text">Upload an audio file to build your first synced cartoon scene.</p>
+        <div class="progress-track" aria-hidden="true">
+          <span id="progress-bar"></span>
+        </div>
+      </div>
+    </aside>
+
+    <section class="preview-card">
+      <div class="preview-header">
+        <div>
+          <h2>Live preview stage</h2>
+          <p>Characters dance, lip-sync, and trigger comic effects based on your audio energy.</p>
+        </div>
+        <div class="transport">
+          <button type="button" id="stop-btn">Stop</button>
+          <span id="time-label">00:00 / 00:00</span>
+        </div>
+      </div>
+      <canvas id="scene-canvas" width="1280" height="720" aria-label="Animated cartoon preview"></canvas>
+      <div class="legend">
+        <span><i class="dot voice"></i> Voice energy drives lip-sync and movement</span>
+        <span><i class="dot music"></i> Music adds ambience and sparkle</span>
+        <span><i class="dot export"></i> Export saves a downloadable WebM video</span>
+      </div>
+    </section>
+  </section>
+
+  <section class="feature-grid">
+    <article>
+      <h3>Audio-reactive animation</h3>
+      <p>Waveform analysis turns louder moments into stronger jumps, confetti bursts, and larger mouth shapes.</p>
+    </article>
+    <article>
+      <h3>Automatic soundtrack blending</h3>
+      <p>The optional backing track sits behind the voice using a dedicated gain control so dialogue stays clear.</p>
+    </article>
+    <article>
+      <h3>Safe, common web APIs</h3>
+      <p>The app uses standard browser APIs that are widely used in production: Canvas, Web Audio, and MediaRecorder.</p>
+    </article>
+  </section>
+</main>


### PR DESCRIPTION
### Motivation
- Provide a browser-based tool that turns an uploaded voice track into a cartoon-style animated video with optional background music without adding a server framework.  
- Use widely supported, dependency-light web APIs (Canvas 2D, Web Audio, `MediaRecorder`) so the feature runs in the client and avoids Flask.  
- Keep the repository self-contained and safe to run in common environments by minimizing runtime external dependencies.

### Description
- Add a new Jekyll layout ` _layouts/app.html` to serve a self-contained static app shell and remove external font preload to reduce external dependencies.  
- Replace the slideshow landing page by updating `index.html` to a full “Audio-to-Cartoon Video Studio” interface with file inputs, controls, preview canvas, and export controls.  
- Add `assets/js/app.js` which implements audio decoding, waveform energy analysis, audio-reactive cartoon rendering on a Canvas, preview playback using the Web Audio API, and client-side WebM export using `MediaRecorder`.  
- Add `assets/css/app.css` for the visual design and update `README.md` to document the non-Flask architecture and local run steps (`./script/setup` and `./script/server`).

### Testing
- Ran `node --check assets/js/app.js` to validate the frontend bundle syntax, which succeeded.  
- Ran a lightweight presence check with Python to verify `index.html`, `_layouts/app.html`, `assets/css/app.css`, and `README.md` are present and non-empty, which succeeded.  
- Attempted `bundle install` and `bundle exec jekyll build`, but `bundle install` failed due to upstream RubyGems HTTP 403 responses (the environment tried to install an older Bundler version), so a full Jekyll build could not be performed here.  
- The site is designed to run locally in a browser using the static files; the export/preview functionality should be tested interactively in a Chromium-based browser (client-side behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bce5e840ec83268d4a967e726ed990)